### PR TITLE
Only create issues for the current file.

### DIFF
--- a/Verilog.novaextension/Scripts/main.js
+++ b/Verilog.novaextension/Scripts/main.js
@@ -128,7 +128,10 @@ class IssuesProvider {
                 // -- Nova seems to want endColumn to be the first "good" column rather than the last bad one.
                 issue.endColumn = Number(issue.column) + 1;
                 
-                issues.push(issue);
+                let fileURI = components[1].slice(1);
+                if (fileURI == tmpFilename) {
+                    issues.push(issue);
+                }
             });
 
             process.onStdout(function(line) {


### PR DESCRIPTION
verilator seems to be able to report issues on other files in the hierarchy when parsing one file.

I’m not sure if Nova supports reporting issue for another file than the currentone but I made a request for helkp in the Nova forums (https://devforum.nova.app/t/creating-issues-for-another-file-than-the-one-being-parsed/2044).

Until then, we should at least make sure we only report issues for the current file.