### PR TITLE
[Issue-2] - fix for x or z variables highlighting differently.

### DIFF
--- a/Verilog.novaextension/Syntaxes/verilog.xml
+++ b/Verilog.novaextension/Syntaxes/verilog.xml
@@ -67,16 +67,34 @@
         </collection>
         <collection name="values">
             <scope name="verilog.value.number.hex">
-                <expression>(\b|')h[0-9a-fA-FxXzZ]+(\b|;)</expression>
+                <expression>\bh[0-9a-fA-F_]+(\b|;)</expression>
             </scope>
             <scope name="verilog.value.number.boolean">
-                <expression>(\b|')b[0-1xXzZ]+(\b|;)</expression>
+                <expression>\bb[0-1_]+(\b|;)</expression>
+            </scope>
+            <scope name="verilog.value.number.octal">
+                <expression>\bo[0-8_]+(\b|;)</expression>
             </scope>
             <scope name="verilog.value.number.dec">
-                <expression>(\b|'d)[0-9xXzZ]+(\b|;)</expression>
+                <expression>\bd[0-9_]+(\b|;)</expression>
             </scope>
-            <scope name="objc.value.number">
-                <expression>(\b|')[0-9xXzZ]+(\b|;)</expression>
+            <scope name="verilog.value.number.default">
+                <expression>\b[0-9_]+(\b|;)</expression>
+            </scope>
+            <scope name="verilog.value.number.base.hex">
+                <expression>'h[0-9a-fA-FxXzZ_]+(\b|;)</expression>
+            </scope>
+            <scope name="verilog.value.number.base.boolean">
+                <expression>'b[0-1xXzZ_]+(\b|;)</expression>
+            </scope>
+            <scope name="verilog.value.number.base.dec">
+                <expression>'d[0-9xXzZ_]+(\b|;)</expression>
+            </scope>
+            <scope name="verilog.value.number.base.octal">
+                <expression>'o[0-9xXzZ_]+(\b|;)</expression>
+            </scope>
+            <scope name="verilog.value.number.base.default">
+                <expression>'[0-9xXzZ_]+(\b|;)</expression>
             </scope>
         </collection>
         <collection name="keywords">


### PR DESCRIPTION
[Issue Link](https://github.com/tsalvo/Verilog-Nova-Extension/issues/2)

proposed fix: create separate value rules that differentiate between numbers defined with a bit length e.g. `8'hFF`, and those without e.g. 1234. allow `xXzZ` only when highlighting the right-hand-component of the number